### PR TITLE
more robust failure responses

### DIFF
--- a/lib/slack/post.rb
+++ b/lib/slack/post.rb
@@ -42,7 +42,7 @@ module Slack
 				when Net::HTTPSuccess
 					return true
 				else
-					fail "There was an error while trying to post. Error was: #{resp.body}"
+					fail "Recieved a #{resp.code} response while trying to post. Response body: #{resp.body}"
 			end
 		end
 

--- a/lib/slack/post/version.rb
+++ b/lib/slack/post/version.rb
@@ -1,5 +1,5 @@
 module Slack
   module Post
-    VERSION = "0.3.4"
+    VERSION = "0.3.5"
   end
 end


### PR DESCRIPTION
update the failure message to include the HTTP status code as well as the body