### PR TITLE
Update TLS version.

### DIFF
--- a/lib/slack/post.rb
+++ b/lib/slack/post.rb
@@ -33,7 +33,7 @@ module Slack
 
 			http = Net::HTTP.new(uri.host, uri.port, config[:proxy_host], config[:proxy_port])
 			http.use_ssl = true
-			http.ssl_version = :TLSv1
+			http.ssl_version = :TLSv1_2
 			http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 			req = Net::HTTP::Post.new(uri.request_uri)
 			req.body = Yajl::Encoder.encode(pkt)


### PR DESCRIPTION
I use this library and recently it started failing.

Error:
```
Posting the messageTraceback (most recent call last):
        11: from slackfood.rb:83:in `<main>'
        10: from slackfood.rb:55:in `tweetit'
         9: from slackfood.rb:55:in `each'
         8: from slackfood.rb:69:in `block in tweetit'
         7: from /workspaces/twitfood/slack-post/lib/slack/post.rb:60:in `post'
         6: from /workspaces/twitfood/slack-post/lib/slack/post.rb:42:in `post_with_attachments'
         5: from /usr/local/lib/ruby/2.7.0/net/http.rb:1483:in `request'
         4: from /usr/local/lib/ruby/2.7.0/net/http.rb:932:in `start'
         3: from /usr/local/lib/ruby/2.7.0/net/http.rb:943:in `do_start'
         2: from /usr/local/lib/ruby/2.7.0/net/http.rb:1009:in `connect'
         1: from /usr/local/lib/ruby/2.7.0/net/protocol.rb:44:in `ssl_socket_connect'
/usr/local/lib/ruby/2.7.0/net/protocol.rb:44:in `connect_nonblock': SSL_connect returned=1 errno=0 state=error: tlsv1 alert protocol version (OpenSSL::SSL::SSLError)
```

I've been looking around and it seems that `:TLSv1_2` does work, however, so I updated that.

You can verify that Slack.com supports TLS v1.2 with `openssl s_client -connect slack.com:443`