### PR TITLE
upgrade TLS to keep up with Slack changes

### DIFF
--- a/lib/slack/post.rb
+++ b/lib/slack/post.rb
@@ -33,7 +33,7 @@ module Slack
 
 			http = Net::HTTP.new(uri.host, uri.port, config[:proxy_host], config[:proxy_port])
 			http.use_ssl = true
-			http.ssl_version = :TLSv1
+			http.ssl_version = :TLSv1_2
 			http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 			req = Net::HTTP::Post.new(uri.request_uri)
 			req.body = Yajl::Encoder.encode(pkt)

--- a/lib/slack/post/version.rb
+++ b/lib/slack/post/version.rb
@@ -1,5 +1,5 @@
 module Slack
   module Post
-    VERSION = "0.3.7"
+    VERSION = "0.4.0"
   end
 end

--- a/slack-post.gemspec
+++ b/slack-post.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 	spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
 	spec.require_paths = ["lib"]
 
-	spec.add_development_dependency "bundler", "~> 1.3"
+	spec.add_development_dependency "bundler", "~> 2.0"
 	spec.add_development_dependency "rake"
 	spec.add_dependency 'yajl-ruby'
 end


### PR DESCRIPTION
Slack has deprecated earlier versions of TLS for security reasons; this will force v1.2 on the poster's side
https://api.slack.com/changelog/2019-07-deprecate-early-tls-versions