### PR TITLE
Use implicit ssl_version

### DIFF
--- a/lib/slack/post.rb
+++ b/lib/slack/post.rb
@@ -33,6 +33,7 @@ module Slack
 
 			http = Net::HTTP.new(uri.host, uri.port, config[:proxy_host], config[:proxy_port])
 			http.use_ssl = true
+			http.min_version = OpenSSL::SSL::TLS1_2_VERSION
 			http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 			req = Net::HTTP::Post.new(uri.request_uri)
 			req.body = Yajl::Encoder.encode(pkt)

--- a/lib/slack/post.rb
+++ b/lib/slack/post.rb
@@ -33,7 +33,6 @@ module Slack
 
 			http = Net::HTTP.new(uri.host, uri.port, config[:proxy_host], config[:proxy_port])
 			http.use_ssl = true
-			http.ssl_version = :TLSv1_2
 			http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 			req = Net::HTTP::Post.new(uri.request_uri)
 			req.body = Yajl::Encoder.encode(pkt)

--- a/lib/slack/post/version.rb
+++ b/lib/slack/post/version.rb
@@ -1,5 +1,5 @@
 module Slack
   module Post
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end


### PR DESCRIPTION
Previously a hardcoded `ssl_version` was used (`TLSv1`, `TLSv1_2`).
Now that TLSv1.3 is out, we should be using it when handshake permits. This allows the use of TLSv1.3!

Here's debug output for the request to Slack for both the current version (using `TLSv1_2`), and this PR 

### Current Code:
```bash
[1] pry(Slack::Post)> http.ssl_version = :TLSv1_2
=> :TLSv1_2
[2] pry(Slack::Post)> http.set_debug_output($stdout)
=> #<IO:<STDOUT>>
[3] pry(Slack::Post)> continue
opening connection to REDACTED.slack.com:443...
opened
starting SSL for REDACTED.slack.com:443...
SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES128-GCM-SHA256
<- "POST /services/hooks/incoming-webhook?token=REDACTED HTTP/1.1\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nContent-Type: application/json\r\nConnection: close\r\nHost: REDACTED.slack.com\r\nContent-Length: 62\r\n\r\n"
<- "{\"channel\":\"#testing\",\"text\":\"no tlsv_\",\"username\":\"im.kevin\"}"
-> "HTTP/1.1 200 OK\r\n"
-> "date: Mon, 04 May 2020 21:52:20 GMT\r\n"
-> "server: Apache\r\n"
-> "strict-transport-security: max-age=31536000; includeSubDomains; preload\r\n"
-> "referrer-policy: no-referrer\r\n"
-> "vary: Accept-Encoding\r\n"
-> "x-slack-backend: h\r\n"
-> "x-frame-options: SAMEORIGIN\r\n"
-> "content-encoding: gzip\r\n"
-> "access-control-allow-origin: *\r\n"
-> "content-length: 22\r\n"
-> "connection: close\r\n"
-> "content-type: text/html\r\n"
-> "x-via: haproxy-www-pp0n\r\n"
-> "\r\n"
reading 22 bytes...
-> "\x1F\x8B\b\x00\x00\x00\x00\x00\x00\x03\xCB\xCF\x06\x00G\xDD\xDCy\x02\x00\x00\x00"
read 22 bytes
Conn close
```


### New Code (this PR): 

```bash
[2] pry(Slack::Post)> http.set_debug_output($stdout)
=> #<IO:<STDOUT>>
[3] pry(Slack::Post)> continue
opening connection to REDACTED.slack.com:443...
opened
starting SSL for REDACTED.slack.com:443...
SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256
<- "POST /services/hooks/incoming-webhook?token=REDACTED HTTP/1.1\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nContent-Type: application/json\r\nConnection: close\r\nHost: REDACTED.slack.com\r\nContent-Length: 62\r\n\r\n"
<- "{\"channel\":\"#testing\",\"text\":\"no tlsv_\",\"username\":\"im.kevin\"}"
-> "HTTP/1.1 200 OK\r\n"
-> "date: Mon, 04 May 2020 21:53:34 GMT\r\n"
-> "server: Apache\r\n"
-> "strict-transport-security: max-age=31536000; includeSubDomains; preload\r\n"
-> "referrer-policy: no-referrer\r\n"
-> "vary: Accept-Encoding\r\n"
-> "x-slack-backend: h\r\n"
-> "x-frame-options: SAMEORIGIN\r\n"
-> "content-encoding: gzip\r\n"
-> "access-control-allow-origin: *\r\n"
-> "content-length: 22\r\n"
-> "connection: close\r\n"
-> "content-type: text/html\r\n"
-> "x-via: haproxy-www-9hkc\r\n"
-> "\r\n"
reading 22 bytes...
-> "\x1F\x8B\b\x00\x00\x00\x00\x00\x00\x03\xCB\xCF\x06\x00G\xDD\xDCy\x02\x00\x00\x00"
read 22 bytes
Conn close
```